### PR TITLE
Option to suppress `docker-entrypoint.sh` output

### DIFF
--- a/7.1/docker-entrypoint.sh
+++ b/7.1/docker-entrypoint.sh
@@ -15,7 +15,9 @@ exec_tpl() {
 exec_init_scripts() {
     shopt -s nullglob
     for f in /docker-entrypoint-init.d/*.sh; do
-        echo "$0: running $f"
+        if [ -z "${DEBUG}" ]; then
+            echo "$0: running $f"
+        fi
         . "$f"
     done
     shopt -u nullglob


### PR DESCRIPTION
Some of our local environment tooling works by running `docker exec` on Drupal PHP containers and doing something with the output. The main usecase is automatically opening the link that `drush uli` outputs. 

But the output from https://github.com/wodby/php/blob/master/7.1/docker-entrypoint.sh#L18 gets in the way of this since on `wodby/drupal-php` it outputs this:

```
/docker-entrypoint.sh: running /docker-entrypoint-init.d/10-drupal-php.sh
```

I would like to propose that this line is suppressed unless the `DEBUG` environment variable is set.