### PR TITLE
Make APP_ROOT chown optional

### DIFF
--- a/7/docker-entrypoint.sh
+++ b/7/docker-entrypoint.sh
@@ -110,7 +110,10 @@ init_git() {
     git config --global user.name "${GIT_USER_NAME:-www-data}"
 }
 
-sudo fix-permissions.sh www-data www-data "${APP_ROOT}"
+if [[ -z "${SKIP_FIX_PERMISSION}" ]]; then
+    sudo fix-permissions.sh www-data www-data "${APP_ROOT}"
+fi
+
 validate_dirs
 init_ssh_client
 init_git


### PR DESCRIPTION
The idea is to allow avoiding the chown in the setup script.

I use user 1000 on my host and I pass that to the docker-compose exec (as in `docker-compose exec --user 1000 php ./vendor/bin/drush --root="/var/www/html/web" ` (I use the composer project template)) now I need to make the app root chown 777 so that I can do anything. But more importantly the user www-data should not have write access to the code but only to `sites/default/files`.
To quote the first paragraph of https://www.drupal.org/node/244924:
> The server file system should be configured so that the web server (e.g. Apache) does not have permission to edit or write the files which it then executes. That is, all of your files should be 'read only' for the Apache process, and owned with write permissions by a separate user.

for me the most convenient would be if that user would have uid 1000, but if it just doesn't exist it is fine anyway since docker-compose can execute things with a specific uid even if the user was not explicitly defined. So the best would be to make it optional so that in my docker-compose.yml I can set an environment variable and be happy.

My current workaround is to mount all the files into `/var/www/html/project`.

I have not tested the script change (and I am not proficient with bash and do all scripting in python) so maybe it can be improved.

