### PR TITLE
Do not run php-fpm with sudo

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -379,4 +379,4 @@ COPY docker-entrypoint.sh /
 COPY actions /usr/local/bin/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["sudo", "php-fpm"]
+CMD ["php-fpm"]

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -272,4 +272,4 @@ COPY docker-entrypoint.sh /
 COPY actions /usr/local/bin/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["sudo", "php-fpm"]
+CMD ["php-fpm"]

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -307,4 +307,4 @@ COPY docker-entrypoint.sh /
 COPY actions /usr/local/bin/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["sudo", "php-fpm"]
+CMD ["php-fpm"]


### PR DESCRIPTION
because otherwise, environment variables passed to the PHP container are missing from the pages loaded in a browser. (Even if PHP FPM's clear_env option is disabled.)

I experienced a weird issue on Travis CI when my PHPUnit tests were running in Wodby's Docker containers. First of all, my tests require authentication information to a 3rd party service and those are being passed as environment variables to the PHP container from the host. I tested this setup on my localhost (OSX - Docker for Mac) multiple times and everything worked as expected. However, on Travis the 3rd party credentials were always missing and therefore the test were always failed.  I had no idea what is going for a long time but then I managed to reproduce this problem on Linux (Ubuntu 17.04) with the same Docker and Docker Compose versions as I have on Mac.

```sh
$ docker version
Client:
 Version:	17.12.0-ce
 API version:	1.35
 Go version:	go1.9.2
 Git commit:	c97c6d6
 Built:	Wed Dec 27 20:11:19 2017
 OS/Arch:	linux/amd64

Server:
 Engine:
  Version:	17.12.0-ce
  API version:	1.35 (minimum version 1.12)
  Go version:	go1.9.2
  Git commit:	c97c6d6
  Built:	Wed Dec 27 20:09:53 2017
  OS/Arch:	linux/amd64
  Experimental:	false

$ docker-compose version
docker-compose version 1.18.0, build 8dd22a9
docker-py version: 2.6.1
CPython version: 2.7.13
OpenSSL version: OpenSSL 1.0.1t  3 May 2016
```

Please compare the following two snippets (from `phpinfo();` returned by `curl webserver/info.php` in the PHP container) to see the problem. The container setup was the same in both cases, only the host OSX was different. PHP FPM's clear env was always disabled.

[linux_php_env_vars.txt](https://github.com/wodby/php/files/1672933/linux_php_env_vars.txt)
[osx_php_env_vars.txt](https://github.com/wodby/php/files/1672934/osx_php_env_vars.txt)

As you can see not only the amount of the available environment variables is different, but also there is another major difference here:

On Linux host:

```html
<tr><td class="e">LOGNAME </td><td class="v">root </td></tr>
<tr><td class="e">USER </td><td class="v">php-fpm </td></tr>
<tr><td class="e">USERNAME </td><td class="v">root </td></tr>
<tr><td class="e">HOME </td><td class="v">/home/php-fpm </td></tr>
```

On OSX host

```html
<tr><td class="e">USER </td><td class="v">www-data </td></tr>
<tr><td class="e">HOME </td><td class="v">/home/www-data </td></tr>
```
For me it seems if the host OS is Linux then the [latest changes](commit/64765ab0f71cea7fdd1c63425c67bf660393a076) causing problems with sharing environment variables with the PHP-FPM worker.

My docker-compose.yml:

```yml
version: "3"

services:
  mariadb:
    image: wodby/mariadb
    environment:
      MYSQL_RANDOM_ROOT_PASSWORD: 1
      MYSQL_DATABASE: drupal
      MYSQL_USER: drupal
      MYSQL_PASSWORD: drupal

  php:
    image: wodby/drupal-php:7.1
    environment:
      PHP_FPM_CLEAR_ENV: "no"
      SIMPLETEST_BASE_URL: http://webserver
      SIMPLETEST_DB: mysql://drupal:drupal@mariadb/drupal
    volumes:
      - codebase:/var/www/html

  webserver:
    image: wodby/php-apache:2.4
    environment:
      APACHE_SERVER_ROOT: /var/www/html
      APACHE_BACKEND_HOST: php
      APACHE_LOG_LEVEL: debug
    volumes:
      - codebase:/var/www/html

volumes:
  codebase:
```
