### PR TITLE
Added png optimisation tool

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -69,6 +69,7 @@ RUN set -xe; \
         openssh \
         openssh-client \
         patch \
+	pngquant=2.12.3-r0 \
         postgresql-client \
         rabbitmq-c=0.8.0-r5 \
         rsync \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -69,7 +69,7 @@ RUN set -xe; \
         openssh \
         openssh-client \
         patch \
-	pngquant=2.12.3-r0 \
+	pngquant \
         postgresql-client \
         rabbitmq-c=0.8.0-r5 \
         rsync \


### PR DESCRIPTION
Current php image already contain a good tool for JPEG files optimisation - `jpegoptim`. We're using it alongside with Drupal module https://www.drupal.org/project/imageapi_optimize_binaries to get good image compression results. At the moment we're lacking a good tool for png images optimisation. Looking at different PNG compression comparisons, `pngquant` seems to offer the best balance between the compression and quality.

We'd love to see it as a part of standard php image. Thanks!