### PR TITLE
Add opencensus PECL package for opentracing instrumentation

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -190,6 +190,7 @@ RUN set -xe; \
         memcached-3.1.3 \
         mongodb-1.5.3 \
         oauth-2.0.3 \
+	opencensus-alpha \
         rdkafka-3.1.0 \
         redis-4.3.0 \
         uuid-1.0.4 \
@@ -208,6 +209,7 @@ RUN set -xe; \
         memcached \
         mongodb \
         oauth \
+	opencensus \
         redis \
         rdkafka \
         uuid \


### PR DESCRIPTION
Installing this PECL extension allows to instrument php code with opentracing. Opencensus provides several exporters: [Zipkin, Jaeger, and others](https://github.com/census-instrumentation/opencensus-php#exporters)

This particular version of the extension has [support for WordPress integrated](https://github.com/census-instrumentation/opencensus-php/tree/master/src/Trace/Integrations) but can be used with any other php framework, just a question of setting your own things to trace with `opencensus_trace_method(.., ..)` function

[Instrumentation of the code](https://github.com/census-instrumentation/opencensus-php#installation--basic-usage) is something as simple as adding a couple of lines to compose.json, example:
```
  "require": {
    ......
    "opencensus/opencensus": "^0.5.*",
    "opencensus/opencensus-exporter-jaeger": "~0.1"
  },
```

and a couple of lines as close to the start of the application as possible will provide wordpress database and cache layer tracing:
```
\OpenCensus\Trace\Integrations\Wordpress::load();
\OpenCensus\Trace\Integrations\Mysql::load();
\OpenCensus\Trace\Integrations\Curl::load();
\OpenCensus\Trace\Integrations\Memcached::load();

opencensus_trace_method('wpdb', 'query');
\OpenCensus\Trace\Tracer::start(new \OpenCensus\Trace\Exporter\JaegerExporter('your-service-name', ['host' => 'jaeger-host']));
```