### PR TITLE
Add yarn package manager to the php image

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -111,7 +111,8 @@ RUN set -xe; \
         postgresql-dev \
         rabbitmq-c-dev \
         tidyhtml-dev \
-        yaml-dev; \
+        yaml-dev \
+	yarn; \
     \
     apk add -U --no-cache -t .wodby-php-edge-run-deps -X http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
         gnu-libiconv=1.15-r2; \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -112,7 +112,7 @@ RUN set -xe; \
         rabbitmq-c-dev \
         tidyhtml-dev \
         yaml-dev \
-	yarn; \
+        yarn; \
     \
     apk add -U --no-cache -t .wodby-php-edge-run-deps -X http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
         gnu-libiconv=1.15-r2; \


### PR DESCRIPTION
Nowadays, js becomes more and more integrated with php. Drupal ecosystem also growth further and projects like https://www.drupal.org/project/webpack appear in the community for handling of progressively decoupled applications. Therefore js package manager accessibility alongside with php becomes more and more regularly used.

Therefore I propose to add yarn to the php image so that php images of Wodby are future-proof. 