### PR TITLE
Add `composer global require hirak/prestissimo`

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -316,6 +316,7 @@ RUN set -xe; \
     chmod 660 /etc/crontabs/www-data; \
     \
     su-exec wodby composer clear-cache; \
+    su-exec wodby composer global require hirak/prestissimo; \
     docker-php-source delete; \
     apk del --purge .wodby-php-build-deps; \
     pecl clear-cache; \


### PR DESCRIPTION
By globally requiring the `hirak/prestissimo` composer package, installing any local packages becomes rapid!

I usually work with Laravel, so I've ran the following test...

```
$ docker run -it --rm wodby/php:7.4 bash
```
```
$ wget https://raw.githubusercontent.com/laravel/laravel/master/composer.json
$ time composer install
```
```
real	3m56.986s
user	0m34.611s
sys	0m26.210s
```

Then I built the php 7.4 image locally with `hirak/prestissimo`

```
$ docker run -it --rm mapsi/php:7.4 bash
```
```
$ wget https://raw.githubusercontent.com/laravel/laravel/master/composer.json
$ time composer install
```
```
real	1m15.155s
user	0m26.242s
sys	0m29.357s
```

I destroyed the containers and re run the tests twice more and the prestissimo version is always more than twice faster than the vanilla version.