### PR TITLE
Adds Microsoft Drivers for PHP for SQL Server

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -120,6 +120,7 @@ RUN set -xe; \
         postgresql-dev \
         rabbitmq-c-dev \
         tidyhtml-dev \
+        unixodbc-dev \
         yaml-dev; \
     \
     apk add -U --no-cache -t .wodby-php-edge-run-deps -X http://dl-cdn.alpinelinux.org/alpine/edge/community/ \
@@ -196,6 +197,12 @@ RUN set -xe; \
     chown -R www-data:www-data /var/log/newrelic/; \
     chmod -R 775 /var/log/newrelic/; \
     \
+    # Microsoft ODBC driver for SQL Server
+    curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.6.1.1-1_amd64.apk && \
+    apk add --allow-untrusted msodbcsql17_17.6.1.1-1_amd64.apk; \
+    curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.6.1.1-1_amd64.apk && \
+    apk add --allow-untrusted mssql-tools_17.6.1.1-1_amd64.apk; \
+    \
     pecl install \
         amqp-1.10.2 \
         apcu-5.1.18 \
@@ -210,8 +217,10 @@ RUN set -xe; \
         mongodb-1.6.0 \
         oauth-2.0.4 \
         pcov \
+        pdo_sqlsrv-5.8.1 \
         rdkafka-4.0.3 \
         redis-4.3.0 \
+        sqlsrv-5.8.1 \
         uuid-1.0.4 \
         xdebug-2.9.6 \
         yaml-2.1.0; \
@@ -230,8 +239,10 @@ RUN set -xe; \
         mongodb \
         oauth \
         pcov \
+        pdo_sqlsrv \
         redis \
         rdkafka \
+        sqlsrv \
         uuid \
         xdebug \
         yaml; \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -202,6 +202,7 @@ RUN set -xe; \
     apk add --allow-untrusted msodbcsql17_17.6.1.1-1_amd64.apk; \
     curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.6.1.1-1_amd64.apk && \
     apk add --allow-untrusted mssql-tools_17.6.1.1-1_amd64.apk; \
+    rm ./*.apk; \
     \
     pecl install \
         amqp-1.10.2 \

--- a/7/tests/php_modules/7.2
+++ b/7/tests/php_modules/7.2
@@ -45,6 +45,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -59,6 +60,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 standard
 tideways_xhprof
 tidy

--- a/7/tests/php_modules/7.3
+++ b/7/tests/php_modules/7.3
@@ -45,6 +45,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -59,6 +60,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 standard
 tideways_xhprof
 tidy

--- a/7/tests/php_modules/7.4
+++ b/7/tests/php_modules/7.4
@@ -45,6 +45,7 @@ PDO
 pdo_mysql
 pdo_pgsql
 pdo_sqlite
+pdo_sqlsrv
 pgsql
 Phar
 posix
@@ -59,6 +60,7 @@ sockets
 sodium
 SPL
 sqlite3
+sqlsrv
 standard
 tideways_xhprof
 tidy

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ You can disable extension by listing them in `$PHP_EXTENSIONS_DISABLE` separated
 | pdo_mysql         |            |            |            |
 | pdo_pgsql         |            |            |            |
 | pdo_sqlite        |            |            |            |
+| pdo_sqlsrv        |  5.8.1     |  5.8.1     |  5.8.1     |
 | pgsql             |            |            |            |
 | Phar              |            |            |            |
 | posix             |            |            |            |
@@ -268,6 +269,7 @@ You can disable extension by listing them in `$PHP_EXTENSIONS_DISABLE` separated
 | sodium            |            |            |            |
 | SPL               |            |            |            |
 | sqlite3           |            |            |            |
+| sqlsrv            |            |            |            |
 | standard          |            |            |            |
 | [tideways_xhprof] | v5.0-beta3 | v5.0-beta3 | v5.0-beta3 |
 | tidy              |            |            |            |


### PR DESCRIPTION
This adds support to Microsoft SQL Server.
Info regarding the setup can be found here: https://docs.microsoft.com/en-us/sql/connect/php/installation-tutorial-linux-mac?view=sql-server-ver15#installing-the-drivers-on-alpine-311