### PR TITLE
Add opcache.preload_user for php 7.4

### DIFF
--- a/7/templates/docker-php-ext-opcache.ini.tmpl
+++ b/7/templates/docker-php-ext-opcache.ini.tmpl
@@ -10,4 +10,5 @@ opcache.enable_cli = {{ getenv "PHP_OPCACHE_ENABLE_CLI" "0" }}
 opcache.huge_code_pages = {{ getenv "PHP_OPCACHE_HUGE_CODE_PAGES" "0" }}
 {{ if (eq (getenv "PHP_VER_MINOR") "7.4") }}
 opcache.preload = "{{ getenv "PHP_OPCACHE_PRELOAD" "" }}"
+opcache.preload_user = "{{ getenv "PHP_OPCACHE_PRELOAD_USER" "" }}"
 {{ end }}


### PR DESCRIPTION
https://www.php.net/manual/en/opcache.preloading.php

preload.php is an arbitrary file that will run once at server startup (PHP-FPM, mod_php, etc.) and load code into persistent memory. If PHP will be run as root (not recommended), the opcache.preload_user value can specify an alternate system user to run the preloading. Running preloading as root is not allowed.

this patch added the `opcache.preload_user` can config from the `env`.
