### PR TITLE
Add sqlite3 binaries

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -79,6 +79,7 @@ RUN set -xe; \
         postgresql-client \
         rabbitmq-c \
         rsync \
+        sqlite \
         su-exec \
         sudo \
         tar \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -79,6 +79,7 @@ RUN set -xe; \
         postgresql-client \
         rabbitmq-c \
         rsync \
+        sqlite \
         su-exec \
         sudo \
         tar \


### PR DESCRIPTION
This is useful when [testing drush locally](https://github.com/drush-ops/drush/blob/6ca8af9/.circleci/config.yml#L68-L69)/running a lightweight instance of a project.