### PR TITLE
allow uids and gids higher than 256000

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -33,8 +33,9 @@ RUN set -xe; \
     existing_user=$(getent passwd "${WODBY_USER_ID}" | cut -d: -f1); \
     if [[ -n "${existing_user}" ]]; then deluser "${existing_user}"; fi; \
     \
-	addgroup -g "${WODBY_GROUP_ID}" -S wodby; \
-	adduser -u "${WODBY_USER_ID}" -D -S -s /bin/bash -G wodby wodby; \
+	apk add --update --no-cache shadow; \
+	groupadd -g "${WODBY_GROUP_ID}" wodby; \
+	useradd  -u "${WODBY_USER_ID}" -m -s /bin/bash -g wodby wodby; \
 	adduser wodby www-data; \
 	sed -i '/^wodby/s/!/*/' /etc/shadow; \
 	\

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -33,8 +33,9 @@ RUN set -xe; \
     existing_user=$(getent passwd "${WODBY_USER_ID}" | cut -d: -f1); \
     if [[ -n "${existing_user}" ]]; then deluser "${existing_user}"; fi; \
     \
-	addgroup -g "${WODBY_GROUP_ID}" -S wodby; \
-	adduser -u "${WODBY_USER_ID}" -D -S -s /bin/bash -G wodby wodby; \
+	apk add --update --no-cache shadow; \
+	groupadd -g "${WODBY_GROUP_ID}" wodby; \
+	useradd  -u "${WODBY_USER_ID}" -m -s /bin/bash -g wodby wodby; \
 	adduser wodby www-data; \
 	sed -i '/^wodby/s/!/*/' /etc/shadow; \
 	\


### PR DESCRIPTION
Instead of adduser and groupuser, use useradd and groupadd so uids and gids are not limited to 256000 when building the image with WODBY_USER_ID and WODBY_GROUP_ID build args.