### PR TITLE
Fix Blackfire on arm64 platform

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -267,13 +267,14 @@ RUN set -xe; \
     \
     # Blackfire extension.
     mkdir -p /tmp/blackfire; \
+    dockerplatform=${TARGETPLATFORM:-linux/amd64}; \
     version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"); \
-    blackfire_url="https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/${version}"; \
+    blackfire_url="https://blackfire.io/api/v1/releases/probe/php/alpine/${dockerplatform##*/}/${version}"; \
     wget -qO- "${blackfire_url}" | tar xz --no-same-owner -C /tmp/blackfire; \
     mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so; \
     if [[ -n "${PHP_DEV}" ]]; then \
         mkdir -p /tmp/blackfire; \
-        curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire; \
+        curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/${dockerplatform##*/} | tar zxp -C /tmp/blackfire; \
         mv /tmp/blackfire/blackfire /usr/local/bin/blackfire; \
         rm -Rf /tmp/blackfire; \
         \

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -259,13 +259,14 @@ RUN set -xe; \
     \
     # Blackfire extension.
     mkdir -p /tmp/blackfire; \
+    dockerplatform=${TARGETPLATFORM:-linux/amd64}; \
     version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"); \
-    blackfire_url="https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/${version}"; \
+    blackfire_url="https://blackfire.io/api/v1/releases/probe/php/alpine/${dockerplatform##*/}/${version}"; \
     wget -qO- "${blackfire_url}" | tar xz --no-same-owner -C /tmp/blackfire; \
     mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so; \
     if [[ -n "${PHP_DEV}" ]]; then \
         mkdir -p /tmp/blackfire; \
-        curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire; \
+        curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/${dockerplatform##*/} | tar zxp -C /tmp/blackfire; \
         mv /tmp/blackfire/blackfire /usr/local/bin/blackfire; \
         rm -Rf /tmp/blackfire; \
     fi; \


### PR DESCRIPTION
The image has support for arm64, but Blackfire doesn't work on `arm64`.

The build for the Blackfire extension uses `amd64` and ignores the target platform.  

How to reproduce:
```
$ docker run -it --env PHP_BLACKFIRE=1 wodby/php:7.4 bash
wodby@php.container:/var/www/html $ php -v
[30-Jun-2022 07:32:03 UTC] PHP Warning:  PHP Startup: Unable to load dynamic library 'blackfire.so' (tried: /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so (Error relocating /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so: unsupported relocation type 7), /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so.so (Error loading shared library /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so.so: No such file or directory)) in Unknown on line 0

Warning: PHP Startup: Unable to load dynamic library 'blackfire.so' (tried: /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so (Error relocating /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so: unsupported relocation type 7), /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so.so (Error loading shared library /usr/local/lib/php/extensions/no-debug-non-zts-20190902/blackfire.so.so: No such file or directory)) in Unknown on line 0
PHP 7.4.30 (cli) (built: Jun 10 2022 00:35:32) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.30, Copyright (c), by Zend Technologies
```