### PR TITLE
Surround PHP_FPM_ENV_VARS with quotes.

### DIFF
--- a/7/templates/zz-www.conf.tmpl
+++ b/7/templates/zz-www.conf.tmpl
@@ -23,7 +23,7 @@ user = {{ getenv "PHP_FPM_USER" "www-data" }}
 group = {{ getenv "PHP_FPM_GROUP" "www-data" }}
 
 {{ if getenv "PHP_FPM_ENV_VARS" }}{{ range jsonArray (getenv "PHP_FPM_ENV_VARS") }}{{ if getenv . }}
-env[{{.}}] = {{ getenv . }}{{ end }}{{ end }}{{ end }}
+env[{{.}}] = "{{ getenv . }}"{{ end }}{{ end }}{{ end }}
 
 ; Pool for health-check pings to avoid spam in access log.
 [ping]

--- a/8/templates/zz-www.conf.tmpl
+++ b/8/templates/zz-www.conf.tmpl
@@ -23,7 +23,7 @@ user = {{ getenv "PHP_FPM_USER" "www-data" }}
 group = {{ getenv "PHP_FPM_GROUP" "www-data" }}
 
 {{ if getenv "PHP_FPM_ENV_VARS" }}{{ range jsonArray (getenv "PHP_FPM_ENV_VARS") }}{{ if getenv . }}
-env[{{.}}] = {{ getenv . }}{{ end }}{{ end }}{{ end }}
+env[{{.}}] = "{{ getenv . }}"{{ end }}{{ end }}{{ end }}
 
 ; Pool for health-check pings to avoid spam in access log.
 [ping]


### PR DESCRIPTION
I just run into the problem of having the variable value that is the string `off`
https://bugs.php.net/bug.php?id=69851
And I notice that keeps fpm from starting because is an empty variable. I think the variables should be surrounded by quotes