### PR TITLE
chore: update libgd

### DIFF
--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -58,6 +58,7 @@ RUN set -xe; \
         less \
         libbz2 \
         libevent \
+        libgd \
         libgomp \
         libjpeg-turbo \
         libjpeg-turbo-utils \


### PR DESCRIPTION
## What

Install the latest version [of `libgd`](https://libgd.github.io/).

## Why

The pre-installed version og GD is 2.1, which is _meaningfully_ old ([released in 2013](https://libgd.github.io/release-2.1.0.html)).