### PR TITLE
remove apk purge for package that is no longer added with apk

### DIFF
--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -394,7 +394,6 @@ RUN set -xe; \
     \
     su-exec wodby composer clear-cache; \
     apk del --purge .wodby-php-build-deps; \
-    apk del --purge .wodby-php-320-build-deps; \
     pecl clear-cache; \
     \
     rm -rf \


### PR DESCRIPTION
Fixes failed build because of a leftover `apk purge` command for package of which the corresponding `apk add` was already removed