### PR TITLE
Remove assert.active INI directive in docker-php-8.3.ini.tmpl

### DIFF
--- a/8/templates/docker-php-8.3.ini.tmpl
+++ b/8/templates/docker-php-8.3.ini.tmpl
@@ -79,4 +79,3 @@ session.lazy_write = {{ getenv "PHP_SESSION_LAZY_WRITE" "on" }}
 
 [Assertion]
 zend.assertions = {{ getenv "PHP_ZEND_ASSERTIONS" "1" }}
-assert.active = {{ getenv "PHP_ASSERT_ACTIVE" "On" }}


### PR DESCRIPTION
Deprecated as of php 8.3

https://php.watch/versions/8.3/assert-multiple-deprecations

Using php on the CLI prints a message

```
[21-Jul-2024 18:14:04 UTC] PHP Deprecated:  PHP Startup: assert.active INI setting is deprecated in Unknown on line 0

Deprecated: PHP Startup: assert.active INI setting is deprecated in Unknown on line 0
```