### PR TITLE
Apply the service init action on container start

### DIFF
--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -457,6 +457,7 @@ EXPOSE 9000
 COPY templates /etc/gotpl/
 COPY docker-entrypoint.sh /
 COPY bin /usr/local/bin/
+COPY init /docker-entrypoint-init.d/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["sudo", "-E", "php-fpm"]

--- a/8/init/90_wodby_init.sh
+++ b/8/init/90_wodby_init.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -n "${DEBUG}" ]]; then
+    set -x
+fi
+
+# Applies the service init action on container start.
+#
+# The init action prepares the application codebase for this image, for example
+# by wiring the generated Wodby config into the application's own settings file
+# and symlinking public files to the persistent volume. Its steps are guarded
+# and idempotent, so when the image was built with the init action already
+# applied this is a no-op.
+#
+# WODBY_INIT_ACTION names a target in /usr/local/bin/actions.mk and is provided
+# as an environment variable rather than baked into the image, so the init
+# action is applied no matter which Dockerfile produced the image.
+#
+# This file is sourced by exec_init_scripts, not executed in a subshell. Do not
+# use "exit" here, it would terminate the entrypoint and stop the container.
+if [[ -n "${WODBY_INIT_ACTION}" ]]; then
+    echo "Applying init action: ${WODBY_INIT_ACTION}"
+    make "${WODBY_INIT_ACTION}" -f /usr/local/bin/actions.mk
+fi


### PR DESCRIPTION
## Summary

Service init actions (`init-drupal`, `init-laravel`, `init-wordpress`, `init`) prepare the application codebase for the image: they wire the generated Wodby config into the application's own settings file and symlink public directories to the persistent files volume.

Until now they ran only as a `RUN` step in the service Dockerfile. An application that builds from its own Dockerfile replaces that file, so the init step was silently dropped. The build succeeded, the container passed its readiness probe, the deployment reported success, and the application started against an uninitialized codebase.

This adds `/docker-entrypoint-init.d/90_wodby_init.sh`, which applies the `actions.mk` target named by `WODBY_INIT_ACTION`. Because the variable is supplied as an environment variable rather than baked into the image, the init action is applied no matter which Dockerfile produced the image.

## Behaviour

- Does nothing when `WODBY_INIT_ACTION` is unset, so standalone and Docker Compose usage is unchanged.
- Init targets are guarded and idempotent, so this is a no-op when the action was already applied during the build.
- Sourced by `exec_init_scripts` rather than executed in a subshell, so it uses an `if` block. An `exit` here would terminate the entrypoint and stop the container.
- Named `90_` so it runs after the existing `10_`/`20_` scripts that generate the config it references.

## Follow-up

Service manifests declare `WODBY_INIT_ACTION` and drop their build-time init step in a separate change. That change requires this image to be released first.
