### PR TITLE
Rename the init action variable out of the reserved namespace

### DIFF
--- a/8/init/90_wodby_init.sh
+++ b/8/init/90_wodby_init.sh
@@ -14,13 +14,13 @@ fi
 # and idempotent, so when the image was built with the init action already
 # applied this is a no-op.
 #
-# WODBY_INIT_ACTION names a target in /usr/local/bin/actions.mk and is provided
-# as an environment variable rather than baked into the image, so the init
-# action is applied no matter which Dockerfile produced the image.
+# WODBY2_SERVICE_INIT_ACTION names a target in /usr/local/bin/actions.mk. It is
+# provided as an environment variable rather than baked into the image, so the
+# init action is applied no matter which Dockerfile produced the image.
 #
 # This file is sourced by exec_init_scripts, not executed in a subshell. Do not
 # use "exit" here, it would terminate the entrypoint and stop the container.
-if [[ -n "${WODBY_INIT_ACTION}" ]]; then
-    echo "Applying init action: ${WODBY_INIT_ACTION}"
-    make "${WODBY_INIT_ACTION}" -f /usr/local/bin/actions.mk
+if [[ -n "${WODBY2_SERVICE_INIT_ACTION}" ]]; then
+    echo "Applying init action: ${WODBY2_SERVICE_INIT_ACTION}"
+    make "${WODBY2_SERVICE_INIT_ACTION}" -f /usr/local/bin/actions.mk
 fi


### PR DESCRIPTION
Reads `WODBY2_SERVICE_INIT_ACTION` instead of `WODBY_INIT_ACTION`.

`WODBY_*` is reserved: `ValidateUserEnvVarName` rejects it, and a service manifest may only declare such a name when a Super Admin, Wodbot, or a full-access member of the `wodby-2` organization publishes it. Importing one of those manifests into any other organization fails with *"Environment variable name ... is reserved by Wodby"*, which made the init action unusable outside the Wodby orgs.

The reserved prefix is `WODBY_` exactly, so `WODBY2_` is outside it — the same escape the existing `WODBY2_MIGRATIONS_ADD_LEGACY_WODBY1_ENV_VARS` marker uses. Verified against `util.ValidateUserEnvVarName`: `WODBY_INIT_ACTION` is rejected, `WODBY2_SERVICE_INIT_ACTION` is allowed.

Must be released before the service manifests switch to the new name, otherwise a manifest would set a variable the deployed image does not read and the init action would silently stop running.